### PR TITLE
Allow use of webmaker-core via npm link

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,10 @@
 var getPages = require('./npm_tasks/get-pages');
 var path = require('path');
+var fs = require('fs');
+var webmakerCorePath = fs.realpathSync(path.resolve(
+  __dirname,
+  'node_modules/webmaker-core'
+));
 
 // Prep all entry points
 var entry = {};
@@ -10,6 +15,11 @@ getPages().forEach(function (page) {
 module.exports = {
   entry: entry,
   devtool: 'source-map', //not good for ff
+
+  // http://webpack.github.io/docs/troubleshooting.html#npm-linked-modules-doesn-t-find-their-dependencies
+  resolve: { fallback: path.join(__dirname, "node_modules") },
+  resolveLoader: { fallback: path.join(__dirname, "node_modules") },
+
   output: {
     path: __dirname + '/app/src/main/assets/www/js',
     filename: '[name].bundle.js'
@@ -19,17 +29,17 @@ module.exports = {
       {
         test: /\.js$/,
         loaders:  ['babel-loader'],
-        include: path.resolve(__dirname, 'node_modules/webmaker-core')
+        include: webmakerCorePath
       },
       {
         test: /\.jsx$/,
         loaders:  ['babel-loader', 'jsx-loader'],
-        include: path.resolve(__dirname, 'node_modules/webmaker-core')
+        include: webmakerCorePath
       },
       {
         test: /\.json$/,
         loader: 'json-loader',
-        include: [path.resolve(__dirname, 'node_modules/webmaker-core'),  path.resolve(__dirname, 'node_modules')]
+        include: [webmakerCorePath,  path.resolve(__dirname, 'node_modules')]
       }
     ]
   }


### PR DESCRIPTION
This makes a few changes to the Webpack configuration that allow it to work with `webmaker-core` regardless of whether or not it's `npm link`ed.

It previously wasn't working while `npm link`ed because the path Webpack was comparing to our include paths was the "real path" of the package, i.e. the place where the symlink led. So we basically just need to use `fs.realpathSync` to get that in our config.

Beyond that, though, there was still a problem with Webpack being unable to find the _dependencies_ of `npm link`ed modules, which has been [solved before](http://webpack.github.io/docs/troubleshooting.html#npm-linked-modules-doesn-t-find-their-dependencies).
